### PR TITLE
chore: misc changes to sp1 tee contracts

### DIFF
--- a/contracts/src/SP1TeeVerifier.sol
+++ b/contracts/src/SP1TeeVerifier.sol
@@ -31,6 +31,9 @@ contract SP1TeeVerifier is ISP1VerifierWithHash, SimpleOwnable {
     ///
     /// @dev Only the owner can add a signer.
     function addSigner(address signer) external onlyOwner {
+        if (signer == address(0)) {
+            revert("Signer cannot be the zero address");
+        }
         signersMap.addSigner(signer);
     }
 

--- a/contracts/src/SimpleOwnable.sol
+++ b/contracts/src/SimpleOwnable.sol
@@ -46,8 +46,9 @@ contract SimpleOwnable {
     ///
     /// @dev Only the owner can renounce the owner role.
     function renounceOwnership() external onlyOwner {
+        address previousOwner = owner;
         owner = address(0);
 
-        emit OwnershipRenounced(owner);
+        emit OwnershipRenounced(previousOwner);
     }
 }


### PR DESCRIPTION
Miscellaneous changes to the contracts. 

### Revert if signer being added is zero address
Since ecrecover returns address(0) for invalid signatures, adding this check ensures that only valid Ethereum addresses can be signers, aligning better with the expectation that signers possess private keys capable of producing valid signatures.

### Misleading Event Emissions in Ownership Function

Should emit previous owner's address for better traceability.