### PR TITLE
fix: bump sp1 deps to 5.2.4, drop dead aurelien/update-tee-version patch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2094,6 +2094,20 @@ name = "bytemuck"
 version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
 
 [[package]]
 name = "byteorder"
@@ -2850,20 +2864,6 @@ name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
-
-[[package]]
-name = "downloader"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ac1e888d6830712d565b2f3a974be3200be9296bc1b03db8251a4cbf18a4a34"
-dependencies = [
- "digest 0.10.7",
- "futures",
- "rand 0.8.5",
- "reqwest",
- "thiserror 1.0.69",
- "tokio",
-]
 
 [[package]]
 name = "dunce"
@@ -4210,11 +4210,11 @@ dependencies = [
 
 [[package]]
 name = "matchers"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
- "regex-automata 0.1.10",
+ "regex-automata",
 ]
 
 [[package]]
@@ -4371,12 +4371,11 @@ dependencies = [
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.46.0"
+version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "overload",
- "winapi",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4640,12 +4639,6 @@ name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
-
-[[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "p256"
@@ -5253,7 +5246,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_xorshift",
- "regex-syntax 0.8.5",
+ "regex-syntax",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -5503,17 +5496,8 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.9",
- "regex-syntax 0.8.5",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.29",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -5524,7 +5508,7 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.5",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -5532,12 +5516,6 @@ name = "regex-lite"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -5554,6 +5532,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2 0.4.8",
@@ -6391,8 +6370,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-build"
-version = "5.2.1"
-source = "git+https://github.com/succinctlabs/sp1?branch=aurelien%2Fupdate-tee-version#4dd728771944b9193e148060c42e553ec7f1a893"
+version = "5.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6c620b00f468a4eeb6050d5641d971b35aa623d2142ecb55d02fd64840c5f02"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -6404,8 +6384,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor"
-version = "5.2.1"
-source = "git+https://github.com/succinctlabs/sp1?branch=aurelien%2Fupdate-tee-version#4dd728771944b9193e148060c42e553ec7f1a893"
+version = "5.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2363566d0d4213d0ffd93cfcc1a5e413e2af8682213d3e65b90ac0af5623e3"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -6442,8 +6423,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-machine"
-version = "5.2.1"
-source = "git+https://github.com/succinctlabs/sp1?branch=aurelien%2Fupdate-tee-version#4dd728771944b9193e148060c42e553ec7f1a893"
+version = "5.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd3ff75c100e24b89a7b513e082ec3e040c4c9f1cd779b6ba475c5bdc1aa7ad"
 dependencies = [
  "bincode",
  "cbindgen",
@@ -6497,8 +6479,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-cuda"
-version = "5.2.1"
-source = "git+https://github.com/succinctlabs/sp1?branch=aurelien%2Fupdate-tee-version#4dd728771944b9193e148060c42e553ec7f1a893"
+version = "5.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7d3b98d9dd20856176aa7048e2da05d0c3e497f500ea8590292ffbd25002ec1"
 dependencies = [
  "bincode",
  "ctrlc",
@@ -6513,8 +6496,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-curves"
-version = "5.2.1"
-source = "git+https://github.com/succinctlabs/sp1?branch=aurelien%2Fupdate-tee-version#4dd728771944b9193e148060c42e553ec7f1a893"
+version = "5.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7a5dc6007e0c1f35afe334e45531e17b8b347fdf73f6e7786ef5c1bc2218e30"
 dependencies = [
  "cfg-if",
  "dashu",
@@ -6534,17 +6518,31 @@ dependencies = [
 
 [[package]]
 name = "sp1-derive"
-version = "5.2.1"
-source = "git+https://github.com/succinctlabs/sp1?branch=aurelien%2Fupdate-tee-version#4dd728771944b9193e148060c42e553ec7f1a893"
+version = "5.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a1ed8d5acbb6cea056401791e79ca3cba7c7d5e17d0d44cd60e117f16b11ca"
 dependencies = [
  "quote",
  "syn 1.0.109",
 ]
 
 [[package]]
+name = "sp1-lib"
+version = "5.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73b8ff343f2405d5935440e56b7aba5cee6d87303f0051974cbd6f5de502f57"
+dependencies = [
+ "bincode",
+ "elliptic-curve 0.13.8",
+ "serde",
+ "sp1-primitives",
+]
+
+[[package]]
 name = "sp1-primitives"
-version = "5.2.1"
-source = "git+https://github.com/succinctlabs/sp1?branch=aurelien%2Fupdate-tee-version#4dd728771944b9193e148060c42e553ec7f1a893"
+version = "5.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e69a03098f827102c54c31a5e57280eb45b2c085de433b3f702e4f9e3ec1641"
 dependencies = [
  "bincode",
  "blake3",
@@ -6562,14 +6560,14 @@ dependencies = [
 
 [[package]]
 name = "sp1-prover"
-version = "5.2.1"
-source = "git+https://github.com/succinctlabs/sp1?branch=aurelien%2Fupdate-tee-version#4dd728771944b9193e148060c42e553ec7f1a893"
+version = "5.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66f439f716cfc44c38d2aea975f1c4a9ed2cc40074ca7e4df8a37a3ff3795eb"
 dependencies = [
  "anyhow",
  "bincode",
  "clap",
  "dirs",
- "downloader",
  "enum-map",
  "eyre",
  "hashbrown 0.14.5",
@@ -6586,6 +6584,7 @@ dependencies = [
  "p3-symmetric",
  "p3-util",
  "rayon",
+ "reqwest",
  "serde",
  "serde_json",
  "serial_test",
@@ -6598,6 +6597,7 @@ dependencies = [
  "sp1-recursion-core",
  "sp1-recursion-gnark-ffi",
  "sp1-stark",
+ "sp1-verifier",
  "thiserror 1.0.69",
  "tracing",
  "tracing-appender",
@@ -6606,8 +6606,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-circuit"
-version = "5.2.1"
-source = "git+https://github.com/succinctlabs/sp1?branch=aurelien%2Fupdate-tee-version#4dd728771944b9193e148060c42e553ec7f1a893"
+version = "5.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c4a3739e84f154becfc7d2a57d23c825ac83313feec64569b86090395c33fab"
 dependencies = [
  "hashbrown 0.14.5",
  "itertools 0.13.0",
@@ -6640,8 +6641,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-compiler"
-version = "5.2.1"
-source = "git+https://github.com/succinctlabs/sp1?branch=aurelien%2Fupdate-tee-version#4dd728771944b9193e148060c42e553ec7f1a893"
+version = "5.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06aa784cfdc5c979da22ad6c36fe393e9005b6b57702fa9bdd041f112ead5ec5"
 dependencies = [
  "backtrace",
  "itertools 0.13.0",
@@ -6661,8 +6663,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-core"
-version = "5.2.1"
-source = "git+https://github.com/succinctlabs/sp1?branch=aurelien%2Fupdate-tee-version#4dd728771944b9193e148060c42e553ec7f1a893"
+version = "5.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be0db07b18f95f4e04f63f7f12a6547efd10601e2ce180aaf7868aa1bd98257"
 dependencies = [
  "backtrace",
  "cbindgen",
@@ -6703,8 +6706,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-derive"
-version = "5.2.1"
-source = "git+https://github.com/succinctlabs/sp1?branch=aurelien%2Fupdate-tee-version#4dd728771944b9193e148060c42e553ec7f1a893"
+version = "5.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b190465c0c0377f3cacfac2d0ac8a630adf8e1bfac8416be593753bfa4f668e"
 dependencies = [
  "quote",
  "syn 1.0.109",
@@ -6712,8 +6716,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-gnark-ffi"
-version = "5.2.1"
-source = "git+https://github.com/succinctlabs/sp1?branch=aurelien%2Fupdate-tee-version#4dd728771944b9193e148060c42e553ec7f1a893"
+version = "5.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "933ef703fb1c7a25e987a76ad705e60bb53730469766363b771baf3082a50fa0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6737,8 +6742,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-sdk"
-version = "5.2.1"
-source = "git+https://github.com/succinctlabs/sp1?branch=aurelien%2Fupdate-tee-version#4dd728771944b9193e148060c42e553ec7f1a893"
+version = "5.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3ae8bc52d12e8fbfdb10c4c8ce7651af04b63d390c152e6ce43d7744bbaf6f"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",
@@ -6789,8 +6795,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-stark"
-version = "5.2.1"
-source = "git+https://github.com/succinctlabs/sp1?branch=aurelien%2Fupdate-tee-version#4dd728771944b9193e148060c42e553ec7f1a893"
+version = "5.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e99d1cc89ba28fc95736afb1e6ad22b9eb689e95a1dbb29cf0e9d1fa4fc2a5c"
 dependencies = [
  "arrayref",
  "hashbrown 0.14.5",
@@ -6816,7 +6823,6 @@ dependencies = [
  "sp1-derive",
  "sp1-primitives",
  "strum 0.26.3",
- "strum_macros 0.26.4",
  "sysinfo",
  "tracing",
 ]
@@ -6885,6 +6891,21 @@ dependencies = [
  "tonic",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "sp1-verifier"
+version = "5.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1904bbb3c2d16a7a11db32900f468149bc66253825e222f2db76f64fb8ffd1ab"
+dependencies = [
+ "blake3",
+ "cfg-if",
+ "hex",
+ "lazy_static",
+ "sha2",
+ "substrate-bn-succinct",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -6985,6 +7006,23 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "substrate-bn-succinct"
+version = "0.6.0-v5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ba32f1b74728f92887c3ad17c42bf82998eb52c9091018f35294e9cd388b0c8"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+ "cfg-if",
+ "crunchy",
+ "lazy_static",
+ "num-bigint 0.4.6",
+ "rand 0.8.5",
+ "rustc-hex",
+ "sp1-lib",
 ]
 
 [[package]]
@@ -7562,14 +7600,14 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
 dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
- "regex",
+ "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,13 +27,9 @@ tracing = "0.1.41"
 # Alerts
 alert-subscriber = { git = "https://github.com/succinctlabs/alert-subscriber.git", branch = "main" }
 
-sp1-sdk = { version = "5.2.1" }
-sp1-prover = { version = "5.2.1" }
+sp1-sdk = { version = "5.2.4" }
+sp1-prover = { version = "5.2.4" }
 
 # [patch.crates-io]
 # sp1-sdk = { path = "../sp1/crates/sdk" }
 # sp1-prover = { path = "../sp1/crates/prover" }
-
-[patch.crates-io]
-sp1-sdk = { git = "https://github.com/succinctlabs/sp1", branch = "aurelien/update-tee-version" }
-sp1-prover = { git = "https://github.com/succinctlabs/sp1", branch = "aurelien/update-tee-version" }


### PR DESCRIPTION
## Context

The `Cargo.toml` `[patch.crates-io]` block pinned `sp1-sdk` and `sp1-prover` to the `aurelien/update-tee-version` branch on `succinctlabs/sp1`. That branch was deleted, so `cargo install` in the EC2 user-data fails with:

```
unable to update https://github.com/succinctlabs/sp1?branch=aurelien/update-tee-version
failed to find branch `aurelien/update-tee-version`
```

The dependent commit (`4dd72877`) is still reachable via PR succinctlabs/sp1#2428's history, but the branch ref is gone.

## Why the patch existed

The patch was a temporary workaround when the released `sp1-sdk 5.2.1` had `SP1_TEE_VERSION = 2`, reverting it to `1` to match the prod TEE deployment.

The same revert was merged into the SP1 repo (succinctlabs/sp1#2428, squash merge `0462e3fe`, 2025-08-26) and has shipped in every subsequent crates.io release. `sp1-sdk 5.2.4` (Dec 2025) carries `SP1_TEE_VERSION = 1` directly.

```
v5.2.1 → SP1_TEE_VERSION = 2  (the patch reverted this)
v5.2.2 → SP1_TEE_VERSION = 1  (revert merged)
v5.2.3 → SP1_TEE_VERSION = 1
v5.2.4 → SP1_TEE_VERSION = 1  ← we use this
```

## Change

- Bump `sp1-sdk` and `sp1-prover` to `5.2.4`.
- Drop the `[patch.crates-io]` override so dependencies resolve from crates.io.

`Cargo.lock` regenerates accordingly: `sp1-sdk` and `sp1-prover` now pin to `registry+https://github.com/rust-lang/crates.io-index` instead of the dead git branch.

## Verification

- `cargo check --release -p sp1-tee-host --bin sp1-tee-server --features server` clean locally (25s).
- `v1` tag re-pushed triggered the deploy workflow; CFN stacks rolled, ASG launched fresh instances on the new launch template, and the cold-start `cargo install` of `sp1-tee-server` succeeded.