### PR TITLE
chore: apply forge fmt to Deploy.s.sol

### DIFF
--- a/contracts/script/Deploy.s.sol
+++ b/contracts/script/Deploy.s.sol
@@ -39,6 +39,8 @@ contract DeployScript is Script {
             string.concat(vm.projectRoot(), "/deployments/", vm.toString(block.chainid), ".json");
 
         vm.writeFile(deploymentOutfile, "");
-        vm.writeJson({json: vm.serializeAddress("", "SP1TeeVerifier", address(sp1TeeVerifier)), path: deploymentOutfile});
+        vm.writeJson({
+            json: vm.serializeAddress("", "SP1TeeVerifier", address(sp1TeeVerifier)), path: deploymentOutfile
+        });
     }
 }


### PR DESCRIPTION
Pre-existing format drift in `contracts/script/Deploy.s.sol` makes the Foundry `forge fmt --check` job fail on every new PR (e.g. #14). Apply the auto-suggested wrap to fix CI.

Whitespace only — no semantic change. Verified locally with `forge fmt --check --root contracts` (clean after this).