### PR TITLE
chore(cdk): drop sp1-tee ASG to minCapacity=1

### DIFF
--- a/cdk/versioned.ts
+++ b/cdk/versioned.ts
@@ -59,7 +59,7 @@ export class Sp1TeeVersionedStack extends cdk.Stack {
             this,
             `SP1_TEE_AutoScalingGroup_${props.releaseTag}`,
             {
-                minCapacity: 2,
+                minCapacity: 1,
                 maxCapacity: 5,
                 launchTemplate,
                 vpc: props.vpc,


### PR DESCRIPTION
## Summary

Drops the `Sp1TeeVersionedStack-v1` ASG to a single instance (`minCapacity = 2 → 1`). `maxCapacity = 5` is unchanged so we can scale up if traffic grows.

## Why

The TEE 2FA service is fronted by `tee.production.succinct.xyz/signers`, which is fetched by sp1-sdk clients on cold-start.

- Real traffic is trivial — kilobytes per request, very low frequency.
- The endpoint is read-only after enclave attestations are written to S3 the first time.
- Mainnet has no on-chain `SP1TEEVerifier` deployment, so no on-chain TEE proof verification flows depend on this.
- Two `m5a.4xlarge` instances at $0.688/hr each = **~$990/mo** (~$11.9k/yr) just for compute.

## Cost impact

| | $/mo | $/yr |
|---|---|---|
| Before (m5a.4xlarge × 2) | ~$990 | ~$11.9k |
| After (m5a.4xlarge × 1) | ~$495 | ~$5.9k |
| **Savings** | **~$495** | **~$5.9k** |

(ALB + NAT + EBS + KMS + secret unchanged at ~$50/mo.)

## Risk

Low. ASG auto-replaces a failed instance in ~2 min — short blip vs. continuous HA. For a cold-start fetch endpoint that's already serving cached data, this is acceptable.

If we later want to push cost down further (~$5/mo or near zero), a follow-up can serve `/signers` directly from cached S3 attestations on a small fallback host (Lambda or `t4g.nano`) via a new CDK construct + `signers-stub` binary. That work is not in scope here.

## Rollback

Revert this PR + force re-push the `v1` tag → workflow re-deploys ASG with min/desired=2.