### PR TITLE
chore(cdk): set sp1-tee ASG desiredCapacity=1 explicitly

### DIFF
--- a/cdk/versioned.ts
+++ b/cdk/versioned.ts
@@ -60,6 +60,7 @@ export class Sp1TeeVersionedStack extends cdk.Stack {
             `SP1_TEE_AutoScalingGroup_${props.releaseTag}`,
             {
                 minCapacity: 1,
+                desiredCapacity: 1,
                 maxCapacity: 5,
                 launchTemplate,
                 vpc: props.vpc,


### PR DESCRIPTION
Follow-up to #16.

## Why

#16 set `minCapacity: 2 → 1`, but did **not** specify `desiredCapacity`. CloudFormation does not auto-decrement an ASG's desired count when min shrinks — it stayed at 2 (the value implicitly set when the stack was first created with `minCapacity: 2`). Result: post-deploy ASG still ran 2 instances, no actual cost savings yet.

## Change

Add `desiredCapacity: 1` to the ASG definition. Now CFN explicitly enforces 1 instance both on initial create and on every subsequent stack update.

## What this PR does NOT do

This PR does not scale the running ASG down on its own. The currently-running ASG drifted from CFN — it was set to `desired=2` by AWS at create time, and CFN does not re-issue that value on updates unless we explicitly specify it (which is what this PR fixes for the next deploy onward).

The one-time scale-down is a manual op step:

```sh
aws autoscaling set-desired-capacity \
  --region us-east-2 \
  --auto-scaling-group-name Sp1TeeVersionedStack-v1-SP1TEEAutoScalingGroupv1ASGA312F233-h5zbgrU2xr9e \
  --desired-capacity 1 \
  --honor-cooldown
```

Done **after** at least one new-launch-template instance is healthy in the ALB target group, to avoid serving 502s during the transition. After this manual step + this PR merge, the IaC and the running state agree at desired=1.

## Cost impact

Same as #16: m5a.4xlarge × 1 vs × 2 = **~$495/mo saved (~$5.9k/yr)**.

## Rollback

Revert this PR. CFN will leave the running ASG's desired alone (it'll be whatever it was last set to). To restore HA = 2 instances, follow up with a manual `set-desired-capacity --desired-capacity 2`.