### PR TITLE
chore(cdk): keep at least 1 sp1-tee instance during rolling updates

### DIFF
--- a/cdk/versioned.ts
+++ b/cdk/versioned.ts
@@ -66,7 +66,11 @@ export class Sp1TeeVersionedStack extends cdk.Stack {
                 vpcSubnets: {
                     subnetType: cdk.aws_ec2.SubnetType.PUBLIC,
                 },
-                updatePolicy: cdk.aws_autoscaling.UpdatePolicy.rollingUpdate(),
+                updatePolicy: cdk.aws_autoscaling.UpdatePolicy.rollingUpdate({
+                    minInstancesInService: 1,
+                    maxBatchSize: 1,
+                    pauseTime: cdk.Duration.minutes(30),
+                }),
             },
         );
 


### PR DESCRIPTION
## Why

The 2026-04-30 deploy of #16 caused a ~20-minute window where `tee.production.succinct.xyz/signers` returned 502 mid-deploy. Sequence:
1. CDK rolling update kicks in (new launch template registered).
2. ASG drains the 2 old instances.
3. ASG launches 2 new instances on the new launch template.
4. New instances spend ~25 min on cold-start (\`cargo install\` of \`sp1-tee-server\` + Nitro EIF build).
5. While both new instances are still cold-starting AND both old instances are already drained, the ALB has zero healthy targets.

Default \`UpdatePolicy.rollingUpdate()\` uses \`minInstancesInService = 0\`, so ASG never blocks the drain on new health.

## Change

```ts
updatePolicy: cdk.aws_autoscaling.UpdatePolicy.rollingUpdate({
    minInstancesInService: 1,
    maxBatchSize: 1,
    pauseTime: cdk.Duration.minutes(30),
})
```

- \`minInstancesInService: 1\` — at least one healthy instance stays in service throughout the rolling update.
- \`maxBatchSize: 1\` — replace one at a time.
- \`pauseTime: 30 min\` — give the new instance enough time to finish cold-start before draining the next one (cold-start measured ~25 min on m5a.4xlarge).

## Effect

Next time we change the launch template (e.g. SP1 version bump, AMI rotation, user-data tweak), the ASG keeps the endpoint healthy throughout the rollout. Trade-off: deploys take longer (1 batch × ~25 min instead of all-at-once), but we avoid customer-visible downtime.

## Out of scope

This PR doesn't touch \`desiredCapacity\` (#17 handles that) or instance type. It only changes how rolling updates are sequenced.

## Rollback

Revert to \`UpdatePolicy.rollingUpdate()\` with no args (defaults).