### PR TITLE
feat: add signers stub binary and Phase 1 deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -131,3 +131,11 @@ jobs:
             - name: Deploy Versioned Stack
               run: |
                   cdk deploy Sp1TeeVersionedStack-${{ env.RELEASE_TAG }} --require-approval never
+
+            - name: Deploy Stub Stack
+              run: |
+                  if [ "${{ steps.env.outputs.environment }}" = "staging" ]; then
+                    cdk deploy Sp1TeeStubStack-staging --require-approval never
+                  else
+                    cdk deploy Sp1TeeStubStack --require-approval never
+                  fi

--- a/app.ts
+++ b/app.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import * as cdk from "aws-cdk-lib";
 import { Sp1TeeBaseStack, Environment } from "./cdk/base";
+import { Sp1TeeStubStack } from "./cdk/stub";
 import { Sp1TeeVersionedStack } from "./cdk/versioned";
 
 const app = new cdk.App();
@@ -57,4 +58,14 @@ new Sp1TeeVersionedStack(app, `Sp1TeeVersionedStack-${releaseTag}`, {
     role: base.role,
     secret: base.secret,
     alertsTopic: base.alertsTopic,
+});
+
+new Sp1TeeStubStack(app, `Sp1TeeStubStack${environment}`, {
+    env: { account: props.env.account, region: props.env.region },
+
+    environment,
+    commit,
+    vpc: base.vpc,
+    loadBalancer: base.loadBalancer,
+    httpsListener: base.httpsListener,
 });

--- a/cdk/stub.ts
+++ b/cdk/stub.ts
@@ -1,0 +1,182 @@
+import * as cdk from "aws-cdk-lib";
+import { Construct } from "constructs";
+import { Environment } from "./base";
+
+export interface Sp1TeeStubProps extends cdk.StackProps {
+    environment: Environment;
+    /**
+     * sp1-tee commit SHA (or branch / tag) to clone on the stub host. Pinning
+     * to a specific commit makes ASG instance replacements reproducible — a
+     * later replacement re-runs cargo install against the same source rather
+     * than tracking whatever happens to be at `main` HEAD.
+     */
+    commit: string;
+    vpc: cdk.aws_ec2.Vpc;
+    loadBalancer: cdk.aws_elasticloadbalancingv2.ApplicationLoadBalancer;
+    httpsListener: cdk.aws_elasticloadbalancingv2.ApplicationListener;
+}
+
+/**
+ * Deploys the `sp1-tee-signers-stub` binary on a small ARM EC2 instance behind
+ * the existing application load balancer. A dedicated listener rule routes
+ * requests carrying the `X-SP1-Tee-Stub: 1` header to the stub target group;
+ * traffic without that header continues to flow to the existing target groups
+ * (`Sp1TeeVersionedStack-*`) untouched.
+ */
+export class Sp1TeeStubStack extends cdk.Stack {
+    constructor(scope: Construct, id: string, props: Sp1TeeStubProps) {
+        super(scope, id, props);
+
+        const userData = this.buildUserData(props.commit);
+
+        // Dedicated IAM role: only what the stub host actually needs.
+        // - SSM agent: `AmazonSSMManagedInstanceCore` (so we can debug via
+        //   Session Manager without opening SSH).
+        // - cfn-signal: CDK adds a stack-scoped `cloudformation:SignalResource`
+        //   policy when `Signals.waitForCount` is used below.
+        // Notably no AmazonS3FullAccess and no `sp1_tee` Secrets read — the
+        // stub reads attestations anonymously via `s3_client_read_only`.
+        const role = new cdk.aws_iam.Role(this, "SP1_TEE_StubInstanceRole", {
+            assumedBy: new cdk.aws_iam.ServicePrincipal("ec2.amazonaws.com"),
+            managedPolicies: [
+                cdk.aws_iam.ManagedPolicy.fromAwsManagedPolicyName(
+                    "AmazonSSMManagedInstanceCore",
+                ),
+            ],
+        });
+
+        // Dedicated SG. CDK auto-adds the ALB SG → port 8080 ingress when the
+        // ASG is attached to the target group below, so no explicit ingress
+        // rule is needed here. Egress defaults to allow-all (rust toolchain
+        // download + crates.io fetch + S3 attestation list).
+        const securityGroup = new cdk.aws_ec2.SecurityGroup(
+            this,
+            "SP1_TEE_StubSecurityGroup",
+            {
+                vpc: props.vpc,
+                description: "SP1 TEE signers-stub host",
+                allowAllOutbound: true,
+            },
+        );
+
+        const launchTemplate = new cdk.aws_ec2.LaunchTemplate(
+            this,
+            "SP1_TEE_StubLaunchTemplate",
+            {
+                instanceType: new cdk.aws_ec2.InstanceType("t4g.medium"),
+                machineImage: cdk.aws_ec2.MachineImage.latestAmazonLinux2023({
+                    cpuType: cdk.aws_ec2.AmazonLinuxCpuType.ARM_64,
+                }),
+                securityGroup,
+                userData,
+                role,
+                blockDevices: [
+                    {
+                        // Root volume bumped to 20 GB to comfortably hold the
+                        // OS, the rust toolchain, the cargo build cache, and
+                        // the 4 GB swapfile that install-stub.sh provisions.
+                        deviceName: "/dev/xvda",
+                        volume: cdk.aws_ec2.BlockDeviceVolume.ebs(20, {
+                            volumeType: cdk.aws_ec2.EbsDeviceVolumeType.GP3,
+                            deleteOnTermination: true,
+                        }),
+                    },
+                ],
+            },
+        );
+
+        const asg = new cdk.aws_autoscaling.AutoScalingGroup(
+            this,
+            "SP1_TEE_StubAutoScalingGroup",
+            {
+                minCapacity: 1,
+                desiredCapacity: 1,
+                maxCapacity: 1,
+                launchTemplate,
+                vpc: props.vpc,
+                vpcSubnets: {
+                    subnetType: cdk.aws_ec2.SubnetType.PUBLIC,
+                },
+                // Block CFN deploy until the instance signals success at the
+                // end of user-data. Timeout sits inside healthCheckGracePeriod
+                // so a stuck install surfaces as a CFN failure before the ASG
+                // starts replacing the instance for ALB-unhealthy reasons.
+                signals: cdk.aws_autoscaling.Signals.waitForCount(1, {
+                    timeout: cdk.Duration.minutes(25),
+                }),
+                healthChecks: cdk.aws_autoscaling.HealthChecks.ec2({
+                    gracePeriod: cdk.Duration.minutes(30),
+                }),
+                updatePolicy: cdk.aws_autoscaling.UpdatePolicy.rollingUpdate({
+                    minInstancesInService: 0,
+                    maxBatchSize: 1,
+                    pauseTime: cdk.Duration.minutes(30),
+                }),
+            },
+        );
+
+        // Inject `cfn-signal` at the end of user-data, paired with the
+        // `signals` block above.
+        userData.addSignalOnExitCommand(asg);
+
+        const targetGroup = new cdk.aws_elasticloadbalancingv2.ApplicationTargetGroup(
+            this,
+            "SP1_TEE_StubTargetGroup",
+            {
+                targets: [asg],
+                protocol: cdk.aws_elasticloadbalancingv2.ApplicationProtocol.HTTP,
+                port: 8080,
+                vpc: props.vpc,
+                healthCheck: {
+                    path: "/health",
+                    protocol: cdk.aws_elasticloadbalancingv2.Protocol.HTTP,
+                    port: "8080",
+                },
+            },
+        );
+
+        new cdk.aws_elasticloadbalancingv2.ApplicationListenerRule(
+            this,
+            "SP1_TEE_StubRule",
+            {
+                listener: props.httpsListener,
+                targetGroups: [targetGroup],
+                conditions: [
+                    cdk.aws_elasticloadbalancingv2.ListenerCondition.httpHeader(
+                        "X-SP1-Tee-Stub",
+                        ["1"],
+                    ),
+                ],
+                // Below the versioned rules at `99 + version` so a request
+                // carrying BOTH `X-SP1-Tee-Stub: 1` and the normal SDK
+                // `X-SP1-Tee-Version` header still lands on the stub during
+                // header-gated validation.
+                priority: 50,
+            },
+        );
+    }
+
+    buildUserData(commit: string): cdk.aws_ec2.UserData {
+        const userData = cdk.aws_ec2.UserData.forLinux();
+
+        // `sudo -u ec2-user -H` runs install-stub.sh as ec2-user with HOME
+        // set to /home/ec2-user, so `~/.cargo/env` and the systemd unit's
+        // hardcoded path agree.
+        const checkoutCmd = commit
+            ? `git checkout --detach ${commit}`
+            : "# no commit pin set — leaving default branch checked out";
+
+        userData.addCommands(
+            "set -euo pipefail",
+            "dnf install -y git aws-cfn-bootstrap",
+            "cd /home/ec2-user",
+            "git clone https://github.com/succinctlabs/sp1-tee.git",
+            "cd sp1-tee",
+            checkoutCmd,
+            "chown -R ec2-user:ec2-user .",
+            "sudo -u ec2-user -H ./scripts/install-stub.sh",
+        );
+
+        return userData;
+    }
+}

--- a/host/Cargo.toml
+++ b/host/Cargo.toml
@@ -18,6 +18,11 @@ name = "validate_signers"
 path = "bin/validate_signers.rs"
 required-features = ["attestations"]
 
+[[bin]]
+name = "sp1-tee-signers-stub"
+path = "bin/signers-stub.rs"
+required-features = ["signers-stub"]
+
 [[example]]
 name = "fibonacci"
 path = "examples/fibonacci.rs"
@@ -79,5 +84,14 @@ attestations = [
     "dep:aws-nitro-enclaves-cose",
     "dep:aws-nitro-enclaves-nsm-api",
     "dep:attestation-doc-validation",
+]
+# Lightweight HTTP stub serving /signers from cached S3 attestations
+# without running the Nitro Enclave. Intended to replace the production
+# fleet for the SDK cold-start fetch path on tiny instances (Lambda or
+# t4g.nano).
+signers-stub = [
+    "attestations",
+    "dep:axum",
+    "dep:tokio",
 ]
 client = ["sp1-sdk/tee-2fa"]

--- a/host/bin/signers-stub.rs
+++ b/host/bin/signers-stub.rs
@@ -74,7 +74,8 @@ async fn get_signers() -> Result<Response, StatusCode> {
             StatusCode::INTERNAL_SERVER_ERROR
         })?;
 
-    tracing::debug!("Fetched {} raw attestations", raw_attestations.len());
+    let total = raw_attestations.len();
+    tracing::debug!("Fetched {} raw attestations", total);
 
     let signers: Vec<_> = raw_attestations
         .iter()
@@ -87,6 +88,15 @@ async fn get_signers() -> Result<Response, StatusCode> {
         })
         .filter_map(|doc| sp1_tee_host::ethereum_address_from_sec1_bytes(doc.public_key.as_ref()?))
         .collect();
+
+    let skipped = total.saturating_sub(signers.len());
+    if skipped > 0 {
+        tracing::warn!(
+            "Skipped {} of {} attestations (verify failed, version mismatch, or bad pubkey)",
+            skipped,
+            total
+        );
+    }
 
     tracing::info!("Returning {} signers", signers.len());
 

--- a/host/bin/signers-stub.rs
+++ b/host/bin/signers-stub.rs
@@ -1,0 +1,104 @@
+//! HTTP stub serving `/signers` from cached S3 attestations.
+//!
+//! Mirrors the `/signers` handler in `bin/server.rs` but does NOT start a
+//! Nitro Enclave or accept `/execute` requests. Designed to run on tiny
+//! instances (e.g. Lambda via lambda-web-adapter, or `t4g.nano`) so the
+//! SDK cold-start fetch path stays cheap and reachable while the
+//! production enclave fleet is scaled to zero between SP1 upgrades.
+//!
+//! Anyone with read-only access to the public `sp1-tee-attestations` S3
+//! bucket can run this — no enclave, no signing keys, no secrets needed.
+
+use axum::{
+    body::Bytes,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    routing::get,
+    Router,
+};
+use clap::Parser;
+use sp1_sdk::network::tee::SP1_TEE_VERSION;
+use std::net::SocketAddr;
+use tokio::net::TcpListener;
+
+#[derive(Parser)]
+struct Args {
+    #[clap(short, long, default_value = "0.0.0.0")]
+    address: String,
+
+    #[clap(short, long, default_value = "8080")]
+    port: u16,
+}
+
+#[tokio::main]
+async fn main() {
+    rustls::crypto::aws_lc_rs::default_provider()
+        .install_default()
+        .expect("Failed to install rustls provider");
+
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()),
+        )
+        .init();
+
+    let args = Args::parse();
+
+    let app = Router::new()
+        .route("/signers", get(get_signers))
+        .route("/health", get(health));
+
+    let addr = SocketAddr::new(args.address.parse().expect("Invalid address"), args.port);
+
+    let listener = TcpListener::bind(addr)
+        .await
+        .expect("Failed to bind to address");
+
+    tracing::info!("signers-stub listening on {}", addr);
+
+    axum::serve(listener, app.into_make_service())
+        .await
+        .expect("Server error");
+}
+
+async fn health() -> &'static str {
+    "ok"
+}
+
+#[tracing::instrument(skip_all)]
+async fn get_signers() -> Result<Response, StatusCode> {
+    let raw_attestations = sp1_tee_host::attestations::get_raw_attestations()
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to fetch attestations from S3: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    tracing::debug!("Fetched {} raw attestations", raw_attestations.len());
+
+    let signers: Vec<_> = raw_attestations
+        .iter()
+        .filter_map(|raw| sp1_tee_host::attestations::verify_attestation(&raw.attestation).ok())
+        .filter(|doc| {
+            doc.user_data
+                .as_ref()
+                .map(|u| u == &SP1_TEE_VERSION.to_le_bytes())
+                .unwrap_or(false)
+        })
+        .filter_map(|doc| sp1_tee_host::ethereum_address_from_sec1_bytes(doc.public_key.as_ref()?))
+        .collect();
+
+    tracing::info!("Returning {} signers", signers.len());
+
+    let body = bincode::serialize(&signers).map_err(|e| {
+        tracing::error!("Failed to serialize signers: {e}");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    Ok((
+        StatusCode::OK,
+        [("content-type", "application/octet-stream")],
+        Bytes::from(body),
+    )
+        .into_response())
+}

--- a/host/src/attestations.rs
+++ b/host/src/attestations.rs
@@ -8,11 +8,15 @@ use aws_sdk_s3::operation::get_object::GetObjectError;
 use aws_sdk_s3::operation::list_objects_v2::ListObjectsV2Error;
 use aws_sdk_s3::primitives::ByteStreamError;
 use aws_sdk_s3::{error::SdkError, operation::put_object::PutObjectError};
-use sp1_tee_common::{CommunicationError, EnclaveRequest, EnclaveResponse};
+use sp1_tee_common::CommunicationError;
+#[cfg(feature = "server")]
+use sp1_tee_common::{EnclaveRequest, EnclaveResponse};
 
 use aws_nitro_enclaves_nsm_api::api::AttestationDoc;
 
+#[cfg(feature = "server")]
 use crate::ethereum_address_from_encoded_point;
+#[cfg(feature = "server")]
 use crate::HostStream;
 
 // Attestations expire every 3 hours and we update every 30 mins.
@@ -144,6 +148,7 @@ pub struct RawAttestation {
     pub attestation: Vec<u8>,
 }
 
+#[cfg(feature = "server")]
 pub async fn retrieve_attestation_from_enclave(
     cid: u32,
     port: u16,

--- a/scripts/install-stub.sh
+++ b/scripts/install-stub.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# Install the SP1 TEE signers stub server.
+# Runs as ec2-user (invoked from CDK user-data via `sudo -u ec2-user -H`).
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Build deps. Full set so aws-lc-sys / cmake / native-bindgen crates compile
+# cleanly on aarch64 (clang and perl in particular are needed by aws-lc-sys
+# even when gcc is the primary toolchain).
+# ---------------------------------------------------------------------------
+sudo dnf install -y \
+    gcc gcc-c++ \
+    cmake make \
+    perl clang \
+    pkgconf-pkg-config \
+    openssl-devel
+
+# ---------------------------------------------------------------------------
+# Swap. The release build of axum + aws-sdk-s3 + tokio peaks well over 2 GB;
+# the t4g.medium host has 4 GB RAM, which is workable but not generous. Add
+# 4 GB of swap as cheap insurance against an OOM-kill during `cargo install`.
+# Idempotent across reruns and instance reboots.
+# ---------------------------------------------------------------------------
+if [ ! -f /swapfile ]; then
+    sudo fallocate -l 4G /swapfile
+    sudo chmod 600 /swapfile
+    sudo mkswap /swapfile
+fi
+
+if ! sudo swapon --show=NAME | grep -qx /swapfile; then
+    sudo swapon /swapfile
+fi
+
+if ! grep -q "^/swapfile " /etc/fstab; then
+    echo "/swapfile none swap sw 0 0" | sudo tee -a /etc/fstab > /dev/null
+fi
+
+# ---------------------------------------------------------------------------
+# Rust toolchain (installs into $HOME/.cargo).
+# ---------------------------------------------------------------------------
+curl https://sh.rustup.rs -sSf | sh -s -- -y
+source "$HOME/.cargo/env"
+
+# ---------------------------------------------------------------------------
+# Build the stub binary.
+# `--no-default-features` drops the `server` feature (Nitro Enclave / vsock
+# deps); `signers-stub` pulls just `attestations + axum + tokio`; `production`
+# selects the production S3 bucket constant.
+# ---------------------------------------------------------------------------
+cargo install --path host \
+    --bin sp1-tee-signers-stub \
+    --locked \
+    --no-default-features \
+    --features signers-stub,production
+
+# ---------------------------------------------------------------------------
+# Install systemd unit.
+# ---------------------------------------------------------------------------
+sudo cp sp1-tee-signers-stub.template.service \
+    /etc/systemd/system/sp1-tee-signers-stub.service
+
+sudo systemctl enable --now sp1-tee-signers-stub.service
+
+echo "sp1-tee-signers-stub installed."

--- a/sp1-tee-signers-stub.template.service
+++ b/sp1-tee-signers-stub.template.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=SP1 TEE Signers Stub
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=ec2-user
+ExecStart=/home/ec2-user/.cargo/bin/sp1-tee-signers-stub --address 0.0.0.0 --port 8080
+Restart=always
+RestartSec=5s
+Environment=RUST_LOG=info
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

Adds `sp1-tee-signers-stub`, a small Rust binary that serves `/signers` from cached S3 attestations without Nitro Enclave deps, and wires it into a Phase 1 deployment behind the existing ALB.

Phase 1 is isolated behind the `X-SP1-Tee-Stub: 1` request header. Normal `/signers` traffic keeps routing to the existing production fleet. The stub listener rule uses priority 50, so explicit stub opt-in wins even when a request also carries the normal SDK `X-SP1-Tee-Version` header.

## Change

- New binary `host/bin/signers-stub.rs`:
  - `GET /signers` reads attestations from S3, filters by `SP1_TEE_VERSION`, and returns `bincode::serialize(Vec<Address>)` matching the existing server wire format.
  - `GET /health` returns `ok`.
  - Logs skipped attestation counts when verification, version filtering, or public key extraction drops entries.
- New `signers-stub` Cargo feature that pulls only `attestations + axum + tokio`, without the Nitro/vsock server deps.
- `host/src/attestations.rs` gates enclave-only imports/functions behind `cfg(feature = "server")`.
- New `Sp1TeeStubStack`:
  - `t4g.medium` ARM host, ASG size 1, 20 GB gp3 root volume.
  - Dedicated stub IAM role: SSM managed policy only, plus CDK-generated stack-scoped `cloudformation:SignalResource` for `cfn-signal`.
  - Dedicated stub security group. CDK adds ALB SG -> stub SG port 8080 ingress through target registration.
  - ALB target group on port 8080 and listener rule priority 50 for `X-SP1-Tee-Stub: 1`.
  - Build-on-boot mirrors the existing production fleet pattern, but pins checkout to `SHORT_SHA` for reproducible ASG replacements.
  - `cfn-signal` with 25 minute timeout, 30 minute health-check grace, `aws-cfn-bootstrap`, 4 GB swapfile, native build deps for ARM, and `cargo install --locked`.
- Deploy workflow now deploys the stub stack after the versioned stack.

## Notes

This intentionally uses source build on the instance for Phase 1 to stay consistent with the current production fleet and keep the first live validation small. Moving to prebuilt binary distribution is cleaner long-term and should be tracked as a separate follow-up.

## Verification

- `cargo check --release -p sp1-tee-host --bin sp1-tee-signers-stub --no-default-features --features signers-stub,production --locked`
- `cargo check --release -p sp1-tee-host --bin sp1-tee-server --features server`
- Byte-compare against the existing endpoint:
  ```sh
  cargo run --release --bin sp1-tee-signers-stub --no-default-features \
    --features 'signers-stub,production' -- --port 8081
  curl -sS -o stub.bin http://127.0.0.1:8081/signers
  curl -sS -o prod.bin -H 'X-SP1-Tee-Version: 1' https://tee.production.succinct.xyz/signers
  cmp stub.bin prod.bin
  ```
- `./node_modules/.bin/tsc --noEmit`
- `bash -n scripts/install-stub.sh`
- `cdk synth Sp1TeeStubStack` with `SHORT_SHA=abc1234` confirmed:
  - listener priority `50`
  - dedicated stub SG has ALB -> 8080 ingress
  - dedicated stub role has only SSM managed policy plus stack-scoped `cloudformation:SignalResource`
  - 20 GB root volume, checkout pin, `cfn-signal`, `CreationPolicy` PT25M, and health grace 1800s
- `cargo +nightly fmt --all -- --check`
- `forge fmt --check --root contracts`
- `forge build --sizes`
- `forge test -vvv`
- GitHub CI green on `5f46ad5`.
