### PR TITLE
feat(cdk): route /signers to stub primary; idle versioned ASG

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -128,10 +128,11 @@ jobs:
                     cdk deploy Sp1TeeBaseStack --require-approval never
                   fi               
 
-            - name: Deploy Versioned Stack
-              run: |
-                  cdk deploy Sp1TeeVersionedStack-${{ env.RELEASE_TAG }} --require-approval never
-
+            # Stub Stack must deploy BEFORE Versioned Stack: this ensures the
+            # priority-30 `/signers` rule is in place before the versioned ASG
+            # scales to zero (idle), so SDK clients fetching `/signers` are
+            # served by the stub throughout the rollout — no `/signers` outage
+            # window mid-deploy.
             - name: Deploy Stub Stack
               run: |
                   if [ "${{ steps.env.outputs.environment }}" = "staging" ]; then
@@ -139,3 +140,7 @@ jobs:
                   else
                     cdk deploy Sp1TeeStubStack --require-approval never
                   fi
+
+            - name: Deploy Versioned Stack
+              run: |
+                  cdk deploy Sp1TeeVersionedStack-${{ env.RELEASE_TAG }} --require-approval never

--- a/cdk/stub.ts
+++ b/cdk/stub.ts
@@ -153,7 +153,7 @@ export class Sp1TeeStubStack extends cdk.Stack {
                 targetGroups: [targetGroup],
                 conditions: [
                     cdk.aws_elasticloadbalancingv2.ListenerCondition.pathPatterns(
-                        ["/signers"],
+                        ["/signers", "/signers/"],
                     ),
                     cdk.aws_elasticloadbalancingv2.ListenerCondition.httpHeader(
                         "X-SP1-TEE-Version",

--- a/cdk/stub.ts
+++ b/cdk/stub.ts
@@ -135,6 +135,38 @@ export class Sp1TeeStubStack extends cdk.Stack {
             },
         );
 
+        // Primary `/signers` route. The stub serves the same response as the
+        // versioned fleet's `/signers` handler (byte-identical, verified live
+        // in the prior phase), but reads cached attestations directly from S3
+        // instead of running an enclave.
+        //
+        // Conditions are ANDed: `/signers` path AND the SDK's normal
+        // `X-SP1-TEE-Version: 1` header. Higher precedence than the versioned
+        // rule at `99 + version` (= 100), so SDK clients land on the stub.
+        // Other paths under that header (`/execute`, `/address`, `/health`)
+        // do not match here and fall through to the versioned rule.
+        new cdk.aws_elasticloadbalancingv2.ApplicationListenerRule(
+            this,
+            "SP1_TEE_StubSignersPathRule",
+            {
+                listener: props.httpsListener,
+                targetGroups: [targetGroup],
+                conditions: [
+                    cdk.aws_elasticloadbalancingv2.ListenerCondition.pathPatterns(
+                        ["/signers"],
+                    ),
+                    cdk.aws_elasticloadbalancingv2.ListenerCondition.httpHeader(
+                        "X-SP1-TEE-Version",
+                        ["1"],
+                    ),
+                ],
+                priority: 30,
+            },
+        );
+
+        // Header-gated validation/debug bypass. Preserved so the stub stays
+        // reachable independently of the path-routed primary rule above —
+        // useful for direct curl checks during incident response.
         new cdk.aws_elasticloadbalancingv2.ApplicationListenerRule(
             this,
             "SP1_TEE_StubRule",
@@ -147,10 +179,6 @@ export class Sp1TeeStubStack extends cdk.Stack {
                         ["1"],
                     ),
                 ],
-                // Below the versioned rules at `99 + version` so a request
-                // carrying BOTH `X-SP1-Tee-Stub: 1` and the normal SDK
-                // `X-SP1-Tee-Version` header still lands on the stub during
-                // header-gated validation.
                 priority: 50,
             },
         );

--- a/cdk/versioned.ts
+++ b/cdk/versioned.ts
@@ -59,8 +59,14 @@ export class Sp1TeeVersionedStack extends cdk.Stack {
             this,
             `SP1_TEE_AutoScalingGroup_${props.releaseTag}`,
             {
-                minCapacity: 1,
-                desiredCapacity: 1,
+                // The `/signers` path is now served by Sp1TeeStubStack (Phase
+                // 2 cutover). The versioned enclave fleet stays defined so it
+                // can be scaled up briefly when a new attestation needs to be
+                // generated (SP1 upgrade, key rotation), but idles at zero by
+                // default. Scale up: `aws autoscaling set-desired-capacity
+                // --desired-capacity 1 --auto-scaling-group-name ...`.
+                minCapacity: 0,
+                desiredCapacity: 0,
                 maxCapacity: 5,
                 launchTemplate,
                 vpc: props.vpc,

--- a/cdk/versioned.ts
+++ b/cdk/versioned.ts
@@ -73,8 +73,15 @@ export class Sp1TeeVersionedStack extends cdk.Stack {
                 vpcSubnets: {
                     subnetType: cdk.aws_ec2.SubnetType.PUBLIC,
                 },
+                // The versioned fleet idles at desired=0 by default (Phase 2
+                // cutover — `/signers` is served by Sp1TeeStubStack). Allow
+                // rolling updates to drop to 0 in-service so launch-template
+                // updates don't conflict with the idle baseline. When the
+                // fleet is scaled back up for attestation generation,
+                // updates will still proceed one instance at a time with the
+                // 30-minute cold-start pause window.
                 updatePolicy: cdk.aws_autoscaling.UpdatePolicy.rollingUpdate({
-                    minInstancesInService: 1,
+                    minInstancesInService: 0,
                     maxBatchSize: 1,
                     pauseTime: cdk.Duration.minutes(30),
                 }),


### PR DESCRIPTION
## Summary

Phase 2 cutover for the `/signers` endpoint. Following Phase 1 (succinctlabs/sp1-tee#19), the stub deployment served byte-identical `/signers` responses behind the `X-SP1-Tee-Stub: 1` header. This PR makes the stub the primary handler for `/signers` and idles the versioned enclave ASG.

## Routing change (`cdk/stub.ts`)

| Priority | Conditions | Target |
|---|---|---|
| 30 (NEW) | path `/signers` or `/signers/` AND header `X-SP1-TEE-Version: 1` | stub TG |
| 50 (preserved) | header `X-SP1-Tee-Stub: 1` | stub TG |
| 100 (existing) | header `X-SP1-TEE-Version: 1` | versioned TG |
| default | — | fixed-response 404 |

Only `/signers` is rerouted to the stub. Other paths under the same header (`/execute`, `/address`, `/health`) still match priority 100.

## Caveat — `/execute`, `/address`, `/health` will return 5xx after deploy

Priority 100 still matches `X-SP1-TEE-Version: 1` for non-`/signers` paths, but the versioned target group is **empty** after this PR's `desiredCapacity = 0` change. So:

- `GET /execute`, `GET /address`, `GET /health` (with the SDK header) → ALB has no healthy target → **503 / 504**.
- This is the **intended Phase 2 end state**. The only confirmed `/signers` consumer is sp1-sdk 5.0.6 cold-start, which is now served by the stub.

To re-enable those paths (e.g. when generating a fresh attestation for an SP1 upgrade or key rotation), scale the versioned ASG back up:

```
aws autoscaling set-desired-capacity \
  --auto-scaling-group-name <Sp1TeeVersionedStack-v1 ASG name> \
  --desired-capacity 1 \
  --honor-cooldown
```

## Capacity change (`cdk/versioned.ts`)

`Sp1TeeVersionedStack-v1` ASG:

|  | Before | After |
|---|---|---|
| `minCapacity` | 1 | 0 |
| `desiredCapacity` | 1 | 0 |
| `maxCapacity` | 5 | 5 |
| `UpdatePolicy.rollingUpdate.minInstancesInService` | 1 | 0 |

The launch template, IAM role, target group, and listener rule are unchanged, so scaling back up is a single CLI call (above).

`minInstancesInService` is dropped to 0 alongside the desired count: a non-zero floor would conflict with the idle baseline whenever a future launch-template change forces an instance refresh on the empty fleet.

## Deploy order (`.github/workflows/deploy.yml`)

The workflow now deploys `Sp1TeeStubStack` BEFORE `Sp1TeeVersionedStack-v1`. The priority-30 `/signers` rule must be live before the versioned ASG scales to zero, otherwise SDK `/signers` requests would hit priority-100 → empty versioned TG → 503 during the rollout window.

```
Base Stack
  ↓
Stub Stack       ← /signers rule live first
  ↓
Versioned Stack  ← then ASG scales down
```

## Verification (local)

- `tsc --noEmit` — clean.
- `cdk synth Sp1TeeStubStack` — clean. Synthesised `SP1TEEStubSignersPathRule`:
  - `Field: path-pattern`, `Values: [/signers, /signers/]`
  - `Field: http-header`, `HttpHeaderName: X-SP1-TEE-Version`, `Values: [1]`
  - `Priority: 30`
- `cdk synth Sp1TeeVersionedStack-v1` — clean. Synthesised:
  - ASG: `MinSize: "0"`, `DesiredCapacity: "0"`, `MaxSize: "5"`
  - `AutoScalingRollingUpdate.MinInstancesInService: 0`
  - `AutoScalingRollingUpdate.MaxBatchSize: 1`, `PauseTime: PT30M`

## Out of scope

- CI prebuilt-binary pipeline.
- Stub monitoring / alerting.
- Documentation updates.

## Rollback

Revert this commit + retag. The priority-30 listener rule disappears, the versioned ASG returns to `min/desired = 1` with `minInstancesInService = 1`, and `/execute` / `/address` come back online once the cold-started instance turns healthy.

Hot-rollback without revert:
```
# Bring the versioned fleet back online.
aws autoscaling set-desired-capacity \
  --auto-scaling-group-name <Sp1TeeVersionedStack-v1 ASG name> \
  --desired-capacity 1 \
  --honor-cooldown

# Optionally remove the priority-30 listener rule so /signers traffic
# returns to versioned TG immediately:
aws elbv2 delete-rule --rule-arn <SP1TEEStubSignersPathRule ARN>
```