### PR TITLE
fix(host): handle empty attestations bucket in signers-stub

### DIFF
--- a/host/bin/server.rs
+++ b/host/bin/server.rs
@@ -81,24 +81,17 @@ async fn get_signers() -> Result<Bytes, ServerError> {
 
     tracing::debug!("Found {} attestations", all_attestations.len());
 
-    let signers = all_attestations
+    let signers: Vec<_> = all_attestations
         .iter()
         .filter_map(|raw| sp1_tee_host::attestations::verify_attestation(&raw.attestation).ok())
         .filter(|doc| {
             doc.user_data
                 .as_ref()
-                .expect("No user data found in attestation")
-                == &SP1_TEE_VERSION.to_le_bytes()
+                .map(|u| u == &SP1_TEE_VERSION.to_le_bytes())
+                .unwrap_or(false)
         })
-        .map(|doc| {
-            sp1_tee_host::ethereum_address_from_sec1_bytes(
-                doc.public_key
-                    .as_ref()
-                    .expect("No public key found in attestation"),
-            )
-            .ok_or(ServerError::FailedToConvertPublicKeyToAddress)
-        })
-        .collect::<Result<Vec<_>, _>>()?;
+        .filter_map(|doc| sp1_tee_host::ethereum_address_from_sec1_bytes(doc.public_key.as_ref()?))
+        .collect();
 
     tracing::debug!("Found {} signers", signers.len());
 

--- a/host/src/attestations.rs
+++ b/host/src/attestations.rs
@@ -220,7 +220,10 @@ pub async fn get_raw_attestations() -> Result<Vec<RawAttestation>, GetAttestatio
 
     for metadata in &contents {
         let Some(key) = metadata.key.clone() else {
-            tracing::warn!("S3 object in {} missing key field; skipping", crate::S3_BUCKET);
+            tracing::warn!(
+                "S3 object in {} missing key field; skipping",
+                crate::S3_BUCKET
+            );
             continue;
         };
 

--- a/host/src/attestations.rs
+++ b/host/src/attestations.rs
@@ -219,11 +219,18 @@ pub async fn get_raw_attestations() -> Result<Vec<RawAttestation>, GetAttestatio
     }
 
     for metadata in &contents {
-        let key = metadata.key.clone().expect("No key found in attestations");
+        let Some(key) = metadata.key.clone() else {
+            tracing::warn!("S3 object in {} missing key field; skipping", crate::S3_BUCKET);
+            continue;
+        };
 
-        let key_as_address = key
-            .parse::<Address>()
-            .expect("Failed to parse key as address");
+        let key_as_address = match key.parse::<Address>() {
+            Ok(addr) => addr,
+            Err(e) => {
+                tracing::warn!("S3 object key {key} not a valid address: {e}; skipping");
+                continue;
+            }
+        };
 
         // Fetch the actual object from S3.
         let object = s3_client

--- a/host/src/attestations.rs
+++ b/host/src/attestations.rs
@@ -209,10 +209,16 @@ pub async fn get_raw_attestations() -> Result<Vec<RawAttestation>, GetAttestatio
 
     let mut attestations = Vec::new();
 
-    for metadata in &attestation_s3_objs
-        .contents
-        .expect("No contents found in attestations")
-    {
+    let contents = attestation_s3_objs.contents.unwrap_or_default();
+    if contents.is_empty() {
+        tracing::warn!(
+            "S3 bucket {} returned no attestation objects; serving empty signer list",
+            crate::S3_BUCKET
+        );
+        return Ok(attestations);
+    }
+
+    for metadata in &contents {
         let key = metadata.key.clone().expect("No key found in attestations");
 
         let key_as_address = key


### PR DESCRIPTION
## Summary

Stop the `signers-stub` from panicking when the `sp1-tee-attestations` S3 bucket is empty. Returns an empty signer list with a warning instead of unwinding into the tokio worker.

## Background

`tee.production.succinct.xyz/signers` has been returning **HTTP 502 Bad Gateway** since the Phase 2 cutover deployed in #20 (2026-04-30). Every request panics in the stub:

```
thread 'tokio-runtime-worker' panicked at host/src/attestations.rs:214:10: No contents found in attestations
```

The panic happens in a worker thread, so the process never crashes and the ASG never replaces it. ALB health checks (`/health`) stay green, but `/signers` 502s on every request.

Root cause: the prod `sp1-tee-attestations` bucket is empty (`KeyCount=0`). The AWS S3 SDK returns `Option<Vec<Object>>` and gives `None` for an empty bucket — so `.expect("No contents found in attestations")` fires.

Why the bucket is empty: the April 29 KMS/secret hard-delete incident wiped the attestation objects. The rollback restored compute, but didn't repopulate S3. #20 then idled the versioned enclave ASG (`Sp1TeeVersionedStack-v1`, desired=0), so no enclave has run to upload fresh attestations since.

Net effect: every fresh `sp1-sdk` 5.0.6 cold-start panics in `NetworkProverBuilder::build()` at `builder.rs:93` (`get_tee_signers().await.expect(...)`).