### PR TITLE
fix(cdk): keep versioned enclave at min=1 to refresh attestations within 3h cert expiry

### DIFF
--- a/cdk/versioned.ts
+++ b/cdk/versioned.ts
@@ -59,29 +59,25 @@ export class Sp1TeeVersionedStack extends cdk.Stack {
             this,
             `SP1_TEE_AutoScalingGroup_${props.releaseTag}`,
             {
-                // The `/signers` path is now served by Sp1TeeStubStack (Phase
-                // 2 cutover). The versioned enclave fleet stays defined so it
-                // can be scaled up briefly when a new attestation needs to be
-                // generated (SP1 upgrade, key rotation), but idles at zero by
-                // default. Scale up: `aws autoscaling set-desired-capacity
-                // --desired-capacity 1 --auto-scaling-group-name ...`.
-                minCapacity: 0,
-                desiredCapacity: 0,
+                // The versioned enclave is the only writer of attestations to
+                // `sp1-tee-attestations`. Attestation docs carry a 3h cert
+                // expiry, and the bucket has a 1-day lifecycle rule, so a
+                // fresh attestation must land at least every ~3h or
+                // `/signers` (served by Sp1TeeStubStack) returns no valid
+                // signers. Idling this fleet to 0 reproduces that failure.
+                // Keep min/desired = 1 so the enclave runs continuously and
+                // refreshes attestations every 30 min (see
+                // `host/src/attestations.rs::ATTESTATION_INTERVAL`).
+                minCapacity: 1,
+                desiredCapacity: 1,
                 maxCapacity: 5,
                 launchTemplate,
                 vpc: props.vpc,
                 vpcSubnets: {
                     subnetType: cdk.aws_ec2.SubnetType.PUBLIC,
                 },
-                // The versioned fleet idles at desired=0 by default (Phase 2
-                // cutover — `/signers` is served by Sp1TeeStubStack). Allow
-                // rolling updates to drop to 0 in-service so launch-template
-                // updates don't conflict with the idle baseline. When the
-                // fleet is scaled back up for attestation generation,
-                // updates will still proceed one instance at a time with the
-                // 30-minute cold-start pause window.
                 updatePolicy: cdk.aws_autoscaling.UpdatePolicy.rollingUpdate({
-                    minInstancesInService: 0,
+                    minInstancesInService: 1,
                     maxBatchSize: 1,
                     pauseTime: cdk.Duration.minutes(30),
                 }),


### PR DESCRIPTION
## Summary

Restore `Sp1TeeVersionedStack-v1` to `min=desired=1`. Partial revert of #20. Stub-primary `/signers` routing and deploy ordering stay as-is.

## Why

`/signers` reads from `sp1-tee-attestations` S3. Two binding constraints:

- Nitro attestation docs expire after **3h** (`attestation_doc_validation` v0.10.0 enforces this).
- Bucket lifecycle deletes objects after **1d**.

The versioned enclave is the **only writer** (`spawn_attestation_task`, every 30 min). #20 idled it to `desired=0`, so within 3h all attestations expired and within 24h the bucket emptied. Stub panicked at `attestations.rs:214`, ALB returned 502, every fresh sp1-sdk 5.0.6 cold-start panicked at `builder.rs:93`. Confirmed in prod from 2026-04-30 to 2026-05-04 21:15 UTC (manual scale-up recovered).